### PR TITLE
Added the preferGlobal flag so that ender is installed globally by defaul

### DIFF
--- a/package.json
+++ b/package.json
@@ -22,5 +22,6 @@
   },
   "bin": {
     "ender": "./bin/ender"
-  }
+  },
+  "preferGlobal": true
 }


### PR DESCRIPTION
Added the preferGlobal flag so that ender is installed globally by default (Enables use of command line tool by default)

This means people do not need to "npm install ender -g" they just need to have ender in their package.json file and it will automatically be installed globally.
