### PR TITLE
ender.js syntax error on package.json without 'main'

### DIFF
--- a/lib/ender.file.js
+++ b/lib/ender.file.js
@@ -251,7 +251,7 @@ var fs = require('fs')
 
     , constructSource: function(packagePath, filePaths, callback) {
         var result = [];
-        if (!filePaths.length) return callback && callback();
+        if (!filePaths.length) return callback && callback('');
         filePaths.forEach(function (p) {
           if (!(/\.js$/.test(p))) {
             p += '.js';


### PR DESCRIPTION
Installing an npm package with a package.json missing the 'main' target (e.g. ender -b mjsunit.runner) assembly fails with

```
Ender was unable to minify your library with UglifyJS!
This usually means you have a js syntax error in one of your packages.
```

and compiled ender.js contains a syntax error due to `undefined` being inserted for the missing 'main' target

```
!function () { var exports = {}, module = { exports: exports }; undefined $.ender(module.exports); }.call($);
```

Best Regards,
Torgeir
