### PR TITLE
assume "index" if `main` is absent from package.json

### DIFF
--- a/lib/ender.file.js
+++ b/lib/ender.file.js
@@ -276,7 +276,9 @@ ENDER.file = module.exports = {
       return callback(null, tree)
     }
 
-    dependencies = Object.keys(dependencies)
+    if (!Array.isArray(dependencies)) {
+      dependencies = Object.keys(dependencies)
+    }
 
     if (isInstallingFromRoot) {
       return ENDER.file.constructDependencyTree(dependencies, directory, function (err, result) {


### PR DESCRIPTION
I just left the string "index" so that one day when coffeescript is supported and someone has an "index.coffee" you can just change your find file functions to look for js and coffee.
