### PR TITLE
Add array dependencies support

### DIFF
--- a/lib/ender.file.js
+++ b/lib/ender.file.js
@@ -276,7 +276,9 @@ ENDER.file = module.exports = {
       return callback(null, tree)
     }
 
-    dependencies = Object.keys(dependencies)
+    if (!Array.isArray(dependencies)) {
+      dependencies = Object.keys(dependencies)
+    }
 
     if (isInstallingFromRoot) {
       return ENDER.file.constructDependencyTree(dependencies, directory, function (err, result) {


### PR DESCRIPTION
A simple check to see if `dependencies` is already an array
