### PR TITLE
Build root module with soure specified by its package.json's 'main'

### DIFF
--- a/lib/ender.file.js
+++ b/lib/ender.file.js
@@ -5,6 +5,7 @@ var fs = require('fs')
   , uglifyJS = require('uglify-js')
   , commonJSBridge = { head: '!function () {\n\n  var module = { exports: {} }, exports = module.exports;'
                      , foot: ' $.ender(module.exports); }.call($);' }
+  , rootName = undefined
   , UTIL = require('./ender.util')
   , FILE = {
 
@@ -180,6 +181,10 @@ var fs = require('fs')
               , name = packageJSON.name
               , dependencies = packageJSON.dependencies;
 
+            if (isRoot) {
+              rootName = name;
+            }
+
             if (dependencies) {
               dependencies = Object.keys(dependencies);
 
@@ -232,7 +237,7 @@ var fs = require('fs')
         FILE.constructDependencyTree(_packages, 'node_modules', function (tree) {
           FILE.flattenDependencyTree(tree, null, function (packages) {
             packages.forEach(function (name, j) {
-              var packagePath = path.join('node_modules', name.replace(/\//g, '/node_modules/'))
+              var packagePath = (name === rootName) ? '.' : path.join('node_modules', name.replace(/\//g, '/node_modules/'))
                 , location = path.join(packagePath, 'package.json');
               path.exists(location, function (exists) {
                 if (!exists) {


### PR DESCRIPTION
This small set of changes allows a developer to build an ender library in the directory of an Ender component. This allows one to build a library while the component is in development (for testing purposes). This code change enable the following to work: <code>$ender build .</code>  

Some other commentary here:
http://stackoverflow.com/questions/6853491/workflow-in-developing-an-enderjs-library-component  
