### PR TITLE
Treat empty dependencies in package.json as undefined dependencies

### DIFF
--- a/lib/ender.file.js
+++ b/lib/ender.file.js
@@ -271,14 +271,15 @@ ENDER.file = module.exports = {
       , dependencies = packageJSON.dependencies
       , packageName = packageJSON.name
 
-    if (!dependencies) {
+    if (dependencies && !Array.isArray(dependencies)) {
+      dependencies = Object.keys(dependencies)
+    }
+    
+    if (!dependencies || dependencies.length == 0) {
       tree[packageName] = 0
       return callback(null, tree)
     }
 
-    if (!Array.isArray(dependencies)) {
-      dependencies = Object.keys(dependencies)
-    }
 
     if (isInstallingFromRoot) {
       return ENDER.file.constructDependencyTree(dependencies, directory, function (err, result) {


### PR DESCRIPTION
I came across a bug in Ender when a adding an Ender package that has an empty object for `dependencies` in `package.json`.  I found this because in my pull request that was just merged for Reqwest, when I removed the Valentine dependency from `package.json`, I [emptied the `dependencies` entry](https://github.com/ded/reqwest/blob/master/package.json#L14-15) instead of removing it.  Currently, users can not add Reqwest to their Ender build.

When processing a `package.json` with an empty `dependencies` object, `constructDependencyTree` gets called, which reads `packages.json` and then calls `findDependencies`.  `findDependencies` checks to see if there's a `dependencies` object and eventually calls `constructDependencyTree` again (from `dependencyFromDirectories`).  The issue is that `constructDependencyTree` expects the `packages` argument to not be empty, so when it is, the callback is never executed.  To resolve this, in `findDependencies` I check to make sure that `dependencies` exists and contains items, otherwise, the callback is immediately executed.
