### PR TITLE
Allow ender to build a runtime that fully encloses module definitions in provided 'this'/'context' to allow for scoping all of ender

### DIFF
--- a/lib/ender.file.js
+++ b/lib/ender.file.js
@@ -411,15 +411,15 @@ ENDER.file = module.exports = {
         if (source && packageName != 'ender-js' && !options.noop) {
           source = [ '!function (context) {\n\n  var module = { exports: {} }, exports = module.exports;'
                    , 'function moduleDefiner() {\n\n    ' + source.replace(/\n/g, '\n    ') + '\n  }\n  moduleDefiner.apply(context);'
-                   , 'var $ = ender = context[\'ender\'],\n    provide = context[\'provide\'],\n    require = context[\'require\'];'
-                   , 'provide("' + packageName.replace(/.*(?=\/)\//, '') + '", module.exports);'
+                   , 'with(context) {'
+                   , '  provide("' + packageName.replace(/.*(?=\/)\//, '') + '", module.exports);'
                    ]
           if (packageJSON.ender) {
-            source.push(content.replace(/\n/g, '\n  '))
+            source.push('  ' + content.replace(/\n/g, '\n    '))
           } else {
-            source.push('$.ender(module.exports);')
+            source.push('  $.ender(module.exports);')
           }
-          source = source.join('\n\n  ') + '\n\n}(this);'
+          source = source.join('\n\n  ') + '\n\n  }\n\n}(this);'
         }
 
         result[index] = source


### PR DESCRIPTION
Useful in places where you might want to wrap up ender as a require JS module without any globals leaking out. 

Also, I actually wasn't able to use noConflict at all w/ bean/bonzo due to expectation they have against a global $ ($ not being enclosed when everything being def'd). 

To get this straight in my head I wrote a little monologue w/ examples in a gist here - 

https://gist.github.com/a1ce9dd2101093330549

And a simplified end product of the changes after an ender build just for domready here - 
https://gist.github.com/1130284

It was a little more complex b/c the API bridge for different modules in the jeesh differs. I probably mentioned that in the gist.

Let me know what you think. This pull is meant conversationally w/ a notional solution that does work but needs to be made sure its inline with other considerations.

I did get a full working jeesh + other modules totally enclosed and working (with this and changes to forks of bonzo & bean) - http://d.scrappz.com/libs/ender.scrappit.js

https://github.com/dzello/bean/commit/799aec2a1e019af58b1a2d5d63f8c457365f52a3
https://github.com/dzello/bonzo/commit/d7d7d1af6789d202cfe4c3928cc07034f4d76ebb
