### PR TITLE
don't remove spaces from command line arguments

### DIFF
--- a/lib/ender.cmd.js
+++ b/lib/ender.cmd.js
@@ -63,7 +63,7 @@ module.exports = {
       }
 
       type = type ? type.toLowerCase() : 'help'
-      cmdOptions = cmdOptions.join(',').replace(/\s|\,(?=\,)/g,'').split(',').filter(function(x){ return x !== '' })
+      cmdOptions = cmdOptions.join(',').replace(/\,(?=\,)/g,'').split(',').filter(function(x){ return x !== '' })
 
       callback(null, type, cmdOptions, options)
     }


### PR DESCRIPTION
don't remove spaces, otherwise there is no way to have spaces in a path name that you supply on the command line (i.e. for a local package). I'm not sure what the intention of the space removal was in the first place though.
