### PR TITLE
fixed typo of `!~packageDependencies`

### DIFF
--- a/lib/ender.npm.js
+++ b/lib/ender.npm.js
@@ -55,7 +55,7 @@ ENDER.npm = module.exports = {
         var connector = head + mid + tail
           , msg
 
-        if (!~packageDependencies) {
+        if (!packageDependencies) {
           msg = (prefix + connector + ' ' + name + (desc ? ' - ' + desc : '')).grey
         } else {
           msg = prefix + connector + ' ' + name.yellow + (desc ? ' - ' + desc : '')


### PR DESCRIPTION
At first I thought this was some silly JS-fu, so I checked it out and I'm pretty sure that this is a type of hitting `~` and `!` at the same time.

```
~[] // -1
~{} // -1
~undefined // -1
~null // -1
~-1 // 0
```

I can't imagine that the only case in which that code should execute is if `packageDependencies` evaluates to -1.
