### PR TITLE
pass stdout fd (1) to npm.install

### DIFF
--- a/lib/ender.npm.js
+++ b/lib/ender.npm.js
@@ -111,7 +111,7 @@ ENDER.npm = module.exports = {
         }
         console.log('installing packages: "' + packages.join(' ') + '"...')
         console.log('this can take a minute...'.yellow)
-        npm.load({ logfd: null, outfd: null }, function (err) {
+        npm.load({ logfd: null, outfd: 1 }, function (err) {
           if (err) {
             if (options.debug) throw err
             return console.log('something went wrong trying to load npm!'.red)
@@ -150,7 +150,7 @@ ENDER.npm = module.exports = {
 
   , uninstall: function (packages, callback) {
       console.log('uninstalling ' + packages.join(' ').yellow)
-      npm.load({ logfd: null, outfd: null }, function (err) {
+      npm.load({ logfd: null, outfd: 1 }, function (err) {
         if (err) {
           callback(err)
           return console.log('something went wrong trying to load npm!')
@@ -168,7 +168,7 @@ ENDER.npm = module.exports = {
   , search: function (keywords, callback) {
       console.log('searching NPM registry...'.grey)
 
-      npm.load({ logfd: null, outfd: null }, function (err) {
+      npm.load({ logfd: null, outfd: 1 }, function (err) {
         if (err) {
           callback(err)
           return console.log('something went wrong trying to load npm!')


### PR DESCRIPTION
I really didn't want to know that intimately how npm works, and I didn't have that much time to spare, but hey, sometimes once you start digging you just can't stop until you figure it out.

This is a fix for Ender running on Node 0.5.10, causing hanging as described in issue #85, on Linux at least.

The culprit is in here: https://github.com/isaacs/npm/blob/master/lib/utils/output.js#L127

Using `outfd: null` causes `outfd` to end up as `0` after [nopt](https://github.com/isaacs/nopt) cleans it up. This then ends up in in the `default` of that `switch` in output.js with `stream = new net.Stream(fd)`. **But**, I don't know why this is a problem, I'm suspecting that in 0.5.x we're ending up with something like an additional wrapper around stdout that isn't properly cleaned up. Or perhaps 0.5.x is just more strict in requiring the closing of streams that you create yourself?

I'm assuming here that the desired behaviour for Ender is to have npm prettyprint the package install information to stdout, because that's what it's doing?

Tested against Node 0.5.10 and 0.4.9 on Linux only, my Mac VM is a little broken at the moment and there's enough of you Mac types to test out there.
