### PR TITLE
Library size unit should be 'kB', 'kByte' or 'K'

### DIFF
--- a/lib/ender.file.js
+++ b/lib/ender.file.js
@@ -97,7 +97,7 @@ ENDER.file = module.exports = {
 
     function writeSize (data) {
       console.log('Your current build type is ' + ('"' + type + '"').yellow)
-      console.log('Your current library size is ' + ((Math.round((data.length/1024) * 10) / 10) + '').yellow + ' kb\n')
+      console.log('Your current library size is ' + ((Math.round((data.length/1024) * 10) / 10) + '').yellow + ' kB\n')
       callback && callback()
     }
   }


### PR DESCRIPTION
'kb' normally refers to kbit. I find things like this very confusing when they are used incorrectly.
