### PR TITLE
npm logfd = 2 (stderr)

### DIFF
--- a/lib/ender.npm.js
+++ b/lib/ender.npm.js
@@ -111,7 +111,7 @@ ENDER.npm = module.exports = {
         }
         console.log('installing packages: "' + packages.join(' ') + '"...')
         console.log('this can take a minute...'.yellow)
-        npm.load({ logfd: null, outfd: 1 }, function (err) {
+        npm.load({ logfd: 2, outfd: 1 }, function (err) {
           if (err) {
             if (options.debug) throw err
             return console.log('something went wrong trying to load npm!'.red)
@@ -150,7 +150,7 @@ ENDER.npm = module.exports = {
 
   , uninstall: function (packages, callback) {
       console.log('uninstalling ' + packages.join(' ').yellow)
-      npm.load({ logfd: null, outfd: 1 }, function (err) {
+      npm.load({ logfd: 2, outfd: 1 }, function (err) {
         if (err) {
           callback(err)
           return console.log('something went wrong trying to load npm!')
@@ -168,7 +168,7 @@ ENDER.npm = module.exports = {
   , search: function (keywords, callback) {
       console.log('searching NPM registry...'.grey)
 
-      npm.load({ logfd: null, outfd: 1 }, function (err) {
+      npm.load({ logfd: 2, outfd: 1 }, function (err) {
         if (err) {
           callback(err)
           return console.log('something went wrong trying to load npm!')


### PR DESCRIPTION
I eventually figured out at least one condition that you can replicate #112 (not exiting). This is similar to #85 & #90 except this time it's the logfd rather than outfd. If you turn on NPM logging you can get this problem, `loglevel = verbose` in your `.npmrc` will do it.

I'm not sure this actually solves #112, that'll have to wait for feedback from @orlin

BTW, I decided to go with stderr (2) rather than stdout (1), I'm not sure that'll make a difference to anyone.
