### PR TITLE
Support for reading packages from files like package.json or npm-shrinkwrap.json.

### DIFF
--- a/lib/ender.js
+++ b/lib/ender.js
@@ -39,13 +39,17 @@ var colors = require('colors')
 
     , build: function (packages, options, callback) {
         packages = options.sans ? packages : ENDER.get.special(options).concat(packages)
-        packages = ENDER.util.unique(packages)
 
-        async.waterfall([
-          async.apply(ENDER.npm.install, packages, options)
-        , async.apply(ENDER.file.assemble, packages, options, writeSource)
-        , writeSource
-        ])
+        ENDER.npm.normalize(packages, function(err, packages){
+            if (err) return callback(err)
+            packages = ENDER.util.unique(packages)
+
+            async.waterfall([
+              async.apply(ENDER.npm.install, packages, options)
+            , async.apply(ENDER.file.assemble, packages, options, writeSource)
+            , writeSource
+            ])
+        })
 
         function writeSource(err, source) {
           async.parallel([
@@ -61,13 +65,16 @@ var colors = require('colors')
         }
 
         newPackages = options.sans ? newPackages : ENDER.get.special(options).concat(newPackages)
-        newPackages = ENDER.util.unique(newPackages)
-
-        async.waterfall([
-          async.apply(ENDER.get.buildHistory, options.use)
-        , ENDER.cmd.process
-        , determinePackagesToAdd
-        ])
+        ENDER.npm.normalize(newPackages, function(err, packages){
+            if (err) return callback(err)
+            newPackages = ENDER.util.unique(packages)
+      
+            async.waterfall([
+              async.apply(ENDER.get.buildHistory, options.use)
+            , ENDER.cmd.process
+            , determinePackagesToAdd
+            ])
+        })
 
         function determinePackagesToAdd(type, activePackages, activeOptions) {
           options = ENDER.util.merge(activeOptions, options)
@@ -105,9 +112,7 @@ var colors = require('colors')
             , async.apply(ENDER.file.uglify, source, options.output, context, options)
             ], callback)
           }
-        }
-
-      }
+        }}
 
     , remove: function (packagesForRemoval, options, callback) {
         if (!packagesForRemoval.length) {

--- a/lib/ender.npm.js
+++ b/lib/ender.npm.js
@@ -103,6 +103,34 @@ ENDER.npm = module.exports = {
       });
     }
 
+  , normalize: function(packages, callback) {
+    async.reduce(packages, [], function(memo, item, next) {
+      fs.stat(item, function(err, stat) {
+        if(err || !stat.isFile()) {
+          memo.push(item)
+          return next(null, memo)
+        }
+        fs.readFile(item, function(err, data) {
+          if(err) {
+             return next(err, memo)
+          }
+          var pkg = JSON.parse(data.toString())
+            , n
+            , v
+          for(n in pkg.dependencies) {
+            if(pkg.dependencies.hasOwnProperty(n)) {
+              v = pkg.dependencies[n]
+              if(typeof v === 'object') {
+                v = v.version
+              }
+              memo.push(n+'@'+v)
+            }
+          }
+          return next(null, memo)
+        })
+      })
+    }, callback)
+  }
   , install: function (packages, options, callback) {
       ENDER.file.createDir('node_modules', function (err) {
         if (err) {


### PR DESCRIPTION
If you provide a path to a json file, `ender build` expects it to be
either a `package.json` or a `npm-shrinkwrap.json`[1] files.
The filename is not important, but the format is, that is to say, if
you provide a `package.json`-like file it must contain a json object
with a `dependencies` hash.

This feature can be useful when trying to lock down dependency versions
between packages. NPM has created a new `shrinkwrap` command to
produce a json file with a list of exact versions to use. Providing
the generated `npm-shrinkwrap.json` file to `ender build` will create
an ender file with just those packages.

For example if you create a `ender.json` like this:

``` javascript
{
  dependencies: {
     "foo": ">= 2.0.1"
     "bar": "1.0.2"
  }
}
```

and execute `ender build ender.json` then only the dependencies included in that file will be built by ender.

[1] http://npmjs.org/doc/shrinkwrap.html
