### PR TITLE
Change module context to exports

### DIFF
--- a/lib/ender.file.js
+++ b/lib/ender.file.js
@@ -446,7 +446,9 @@ ENDER.file = module.exports = {
 
         if (source && packageName != 'ender-js' && !options.noop) {
           source = [ '(function () {\n\n  var module = { exports: {} }, exports = module.exports;'
-                   , source.replace(/\n/g, '\n  ')
+                   , '(function () {'
+                   , '  ' + source.replace(/\n/g, '\n    ')
+                   , '}).call(exports);'
                    , 'provide("' + strippedName + '", module.exports);'
                    ]
 


### PR DESCRIPTION
Here's a pull request that changes the module `this` context to `exports` instead of `window`. It adds an extra level of scope which I'm normally against because it adds to complexity and can impact performance when used excessively, but I don't see another way of doing it just now. If you can think of one, tell me and I'll rewrite it.
