### PR TITLE
Ignore .bin directory in getDependenciesFromDirectory

### DIFF
--- a/lib/package-util.js
+++ b/lib/package-util.js
@@ -113,9 +113,12 @@ var fs                = require('fs')
 
       path.exists(dir, function (exists) {
         if (!exists) return callback(null, [])
-        fs.readdir(dir, function (err) {
+        fs.readdir(dir, function (err, files) {
           if (err) return callback(new FilesystemError(err))
-          callback.apply(null, arguments)
+          files = files.filter(function(file) {
+            return file !== '.bin'
+          });
+          callback.call(null, err, files)
         })
       })
     }

--- a/test/functional/build-packages-with-binaries-test.js
+++ b/test/functional/build-packages-with-binaries-test.js
@@ -1,0 +1,77 @@
+/*!
+ * ENDER - The open module JavaScript framework
+ *
+ * Copyright (c) 2011-2012 @ded, @fat, @rvagg and other contributors
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is furnished
+ * to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
+
+var testCase = require('buster').testCase
+  , fs = require('fs')
+  , path = require('path')
+  , functionalCommon = require('./common')
+
+testCase('Functional: build packages which contain binaries', {
+    'setUp': function () {
+      this.timeout = 30000
+      assert.match.message = '${2}'
+      refute.match.message = '${2}'
+    }
+
+    /**
+     * tax depends on jshint which has binaries. This tests a
+     * regression where packages depending on packages containing
+     * binaries could not be built since - in this case - the
+     * directory `node_modules/tax/node_moules/.bin` (which contains
+     * the jshint binary) was regarded as a dependeny of tax.
+     */
+  , '`ender build tax@0.0.1`': function (done) {
+      var files = [ 'ender.js', 'ender.min.js' ]
+      functionalCommon.runEnder(
+          'build tax@0.0.1'
+        , files
+        , function (err, dir, fileContents, stdout, stderr, callback) {
+            refute(err)
+            refute(stderr)
+
+            assert.stdoutRefersToNPMPackages(stdout, 'ender-js tax@0.0.1')
+            assert.stdoutReportsBuildCommand(stdout, 'ender build tax@0.0.1')
+            assert.stdoutReportsOutputSizes(stdout)
+            assert.hasVersionedPackage(stdout, 'tax', 'stdout')
+            assert.hasVersionedPackage(stdout, 'jshint', 'stdout')
+
+            fileContents.forEach(function (contents, i) {
+              assert.match(
+                  contents
+                , /Build: ender build tax@0.0.1$/m
+                , files[i] + ' contains correct build command'
+              )
+              assert.sourceHasProvide(contents, 'tax', files[i])
+              assert.sourceHasProvide(contents, 'jshint', files[i])
+            })
+
+            functionalCommon.verifyNodeModulesDirectories(
+                dir
+              , 'ender-js tax'.split(' ')
+              , callback.bind(null, done)
+            )
+        })
+    }
+})

--- a/test/functional/common.js
+++ b/test/functional/common.js
@@ -39,6 +39,7 @@ var buster = require('buster')
 buster.assertions.add('sourceHasProvide', {
     assert: function (source, pkg, file) {
       var re = makeSourceProvideRegex(pkg)
+      source = source || ''
       this.times = source.split(re).length - 1
       return this.times == 1
     }
@@ -48,6 +49,7 @@ buster.assertions.add('sourceHasProvide', {
 buster.assertions.add('sourceHasStandardWrapFunction', {
     assert: function (source, pkg, file) {
       var re = new RegExp('\\s*\\}\\)?\\([\'"]' + pkg + '[\'"],.*?function\\s*\\([^\\)]*\\)\\s*\\{')
+      source = source || ''
       this.times = source.split(re).length - 1
       return this.times == 1
     }
@@ -57,6 +59,7 @@ buster.assertions.add('sourceHasStandardWrapFunction', {
 buster.assertions.add('sourceContainsProvideStatements', {
     assert: function (source, times, file) {
       var re = makeSourceProvideRegex('[\\w\\-]+')
+      source = source || ''
       this.times = source.split(re).length - 1
       return this.times == times
     }
@@ -104,6 +107,7 @@ buster.assertions.add('stdoutReportsOutputSizes', {
 
 buster.assertions.add('sourceHasCopyrightComments', {
     assert: function (source, expectedComments, sourceName) {
+      source = source || ''
       return source.split(copyrightCommentRe).length - 1 == expectedComments
     }
   , assertMessage: '${2} has ${1} copyright comments'

--- a/test/unit/package-util-test.js
+++ b/test/unit/package-util-test.js
@@ -370,6 +370,24 @@ testCase('Package util', {
             done()
           })
       }
+
+    , 'test filtering of .bin directory': function (done) {
+          var fsMock = this.mock(fs)
+            , pathMock = this.mock(path)
+            , packageName = 'apackage'
+            , parents = []
+            , resolvedDir = path.resolve('node_modules/apackage/node_modules')
+
+          pathMock.expects('exists').withArgs(resolvedDir).callsArgWith(1, true)
+
+          fsMock.expects('readdir').withArgs(resolvedDir).callsArgWith(1, null, [ '.bin', 'some', 'other', 'modules' ])
+
+          packageUtil.getDependenciesFromDirectory(parents, packageName, function (err, dependencies) {
+            refute(err)
+            assert.equals(dependencies, [ 'some', 'other', 'modules' ])
+            done()
+          })
+        }
     }
 })
 


### PR DESCRIPTION
Otherwise packages which depenend on packages that contain binaries
can not be used in a build.

Assume the following directory structure:

```
node_modules/
  some_package/
    node_modules/
      .bin/
      some_package_with_bin/
```

The `.bin` directory is created by npm to provide stubs for the binaries in `some_package_with_bin`. Now running `ender build some_package` fails with a cryptic error message since it tries to pull in a package `.bin` which `some_package` seems to depend on.
