### PR TITLE
Updated `package.json` deps to latest UglifyJS.

### DIFF
--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
   , "dependencies": {
       "npm": ">= 1.1.26"
     , "colors": ">= 0.6.0"
-    , "uglify-js": ">= 1.3.4"
+    , "uglify-js": "1.3.4"
     , "async": ">= 0.1.22"
     }
   , "devDependencies": {


### PR DESCRIPTION
UglifyJS < 1.3.2 produces [broken](https://github.com/mishoo/UglifyJS/issues/420) minified code that affects Ender builds.
UglifyJS ≥ 1.3.2 solves this issue.
