### PR TITLE
Add uglify-js as an optionalDependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -33,6 +33,9 @@
       , "jshint"           : "*"
       , "mkfiletree"       : "*"
     }
+  , "optionalDependencies": {
+        "uglify-js"        : "^2.4.0"
+  }
   , "bin": {
         "ender"       : "./bin/ender"
     }


### PR DESCRIPTION
Before, uglify-js was not installed by `npm install` on a fresh clone. This caused several test cases to fail.