### PR TITLE
Use console.log instead of util.print

### DIFF
--- a/lib/util.js
+++ b/lib/util.js
@@ -137,9 +137,9 @@ var fs              = require('fs')
     }
 
   , defaultLogger = {
-        info   : function (template) { sysUtil.print(renderTemplate(template) + '\n') }
-      , warn   : function (template) { sysUtil.print(renderTemplate(template) + '\n') }
-      , error  : function (template) { sysUtil.print(renderTemplate(template) + '\n') }
+        info   : function (template) { console.log(renderTemplate(template)) }
+      , warn   : function (template) { console.log(renderTemplate(template)) }
+      , error  : function (template) { console.log(renderTemplate(template)) }
     }
 
 


### PR DESCRIPTION
On node v0.11, `util.print` is deprecated. This PR replaces calls to `util.print` with calls to `console.log`.