### PR TITLE
docs: Fix simple typo, preceeding -> preceding

### DIFF
--- a/lib/main.js
+++ b/lib/main.js
@@ -67,7 +67,7 @@ var argsParser = require('./args-parser')
       if (typeof argv == 'string') {
         // for API use: ender.exec('ender <cmd>', cb)
         argv = argv.split(/\s/).slice(1)
-        parseType = 'parseClean' // parseClean knows there aren't 2 preceeding tokens
+        parseType = 'parseClean' // parseClean knows there aren't 2 preceding tokens
       }
 
       try {


### PR DESCRIPTION
There is a small typo in lib/main.js.

Should read `preceding` rather than `preceeding`.

